### PR TITLE
Fix GSM response parsing for BG96 AT+QCSQ command

### DIFF
--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -68,7 +68,7 @@ uint32_t CellularSrcTokenSuccessTableSize = sizeof( CellularSrcTokenSuccessTable
 /* FreeRTOS Cellular Common Library porting interface. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
 const char * CellularUrcTokenWoPrefixTable[] =
-{ "NORMAL POWER DOWN", "PSM POWER DOWN", "RDY" };
+{ "POWERED DOWN", "PSM POWER DOWN", "RDY" };
 /* FreeRTOS Cellular Common Library porting interface. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
 uint32_t CellularUrcTokenWoPrefixTableSize = sizeof( CellularUrcTokenWoPrefixTable ) / sizeof( char * );

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -228,6 +228,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     int32_t tempValue = 0;
     bool parseStatus = true;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+    bool isGsm = false;
 
     if( ( pSignalInfo == NULL ) || ( pQcsqPayload == NULL ) )
     {
@@ -237,7 +238,8 @@ static bool _parseSignalQuality( char * pQcsqPayload,
 
     if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
-        if( ( strcmp( pToken, "GSM" ) != 0 ) &&
+        isGsm = strcmp( pToken, "GSM" ) == 0;
+        if( ( !isGsm ) &&
             ( strcmp( pToken, "CAT-M1" ) != 0 ) &&
             ( strcmp( pToken, "CAT-NB1" ) != 0 ) )
         {
@@ -269,7 +271,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->rsrp = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 
@@ -288,7 +294,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->sinr = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 
@@ -309,7 +319,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->rsrq = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -65,7 +65,7 @@ CellularAtParseTokenMap_t CellularUrcHandlerTable[] =
     { "CEREG",             Cellular_CommonUrcProcessCereg },
     { "CGREG",             Cellular_CommonUrcProcessCgreg },
     { "CREG",              Cellular_CommonUrcProcessCreg  },
-    { "NORMAL POWER DOWN", _Cellular_ProcessPowerDown     },
+    { "POWERED DOWN", _Cellular_ProcessPowerDown     },
     { "PSM POWER DOWN",    _Cellular_ProcessPsmPowerDown  },
     { "QIND",              _Cellular_ProcessIndication    },
     { "QIOPEN",            _Cellular_ProcessSocketOpen    },


### PR DESCRIPTION
Fix support for signal quality reporting when the modem is connected via GSM.

Description
-----------
Ignores LTE only signal quality values in the case the modem is connected via GSM

Test Steps
-----------
Issue an AT+QCSQ command against a BG96 modem connected via GSM

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Note that I'm running tests for my own project and it successfully was able to get an rssi measurement connected via GSM. In any case, feel free to commandeer the PR

Related Issue
-----------
Fixes #8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
