### PR TITLE
Add BG96 support direct push socket

### DIFF
--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -185,7 +185,7 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
             /* Register the URC data callback. */
             if( cellularStatus == CELLULAR_SUCCESS )
             {
-                cellularStatus = _Cellular_RegisterUrcDataCallback( pContext, Cellular_BG96UrcDataCallback, pContext );
+                cellularStatus = _Cellular_RegisterInputBufferCallback( pContext, Cellular_BG96InputBufferCallback, pContext );
             }
         }
         #endif /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -158,7 +158,7 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
         ( void ) memset( &cellularBg96Context, 0, sizeof( cellularModuleContext_t ) );
 
         /* Create the mutex for DNS. */
-        status = PlatformMutex_Create( &cellularBg96Context.dnsQueryMutex, false );
+        status = PlatformMutex_Create( &cellularBg96Context.contextMutex, false );
 
         if( status == false )
         {
@@ -171,7 +171,7 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
 
             if( cellularBg96Context.pktDnsQueue == NULL )
             {
-                PlatformMutex_Destroy( &cellularBg96Context.dnsQueryMutex );
+                PlatformMutex_Destroy( &cellularBg96Context.contextMutex );
                 cellularStatus = CELLULAR_NO_MEMORY;
             }
             else
@@ -179,6 +179,16 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
                 *ppModuleContext = ( void * ) &cellularBg96Context;
             }
         }
+
+        #if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+        {
+            /* Register the URC data callback. */
+            if( cellularStatus == CELLULAR_SUCCESS )
+            {
+                cellularStatus = _Cellular_RegisterUrcDataCallback( pContext, Cellular_BG96UrcDataCallback, pContext );
+            }
+        }
+        #endif /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
     }
 
     return cellularStatus;
@@ -202,7 +212,7 @@ CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
         vQueueDelete( cellularBg96Context.pktDnsQueue );
 
         /* Delete the mutex for DNS. */
-        PlatformMutex_Destroy( &cellularBg96Context.dnsQueryMutex );
+        PlatformMutex_Destroy( &cellularBg96Context.contextMutex );
     }
 
     return cellularStatus;

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -181,13 +181,13 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
         }
 
         #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
-        {
-            /* Register the URC data callback. */
-            if( cellularStatus == CELLULAR_SUCCESS )
             {
-                cellularStatus = _Cellular_RegisterInputBufferCallback( pContext, Cellular_BG96InputBufferCallback, pContext );
+                /* Register the URC data callback. */
+                if( cellularStatus == CELLULAR_SUCCESS )
+                {
+                    cellularStatus = _Cellular_RegisterInputBufferCallback( pContext, Cellular_BG96InputBufferCallback, pContext );
+                }
             }
-        }
         #endif /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
     }
 

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -180,7 +180,7 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
             }
         }
 
-        #if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+        #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
         {
             /* Register the URC data callback. */
             if( cellularStatus == CELLULAR_SUCCESS )

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -50,7 +50,7 @@
 #define DATA_READ_TIMEOUT_MS                       ( 50000UL )
 
 #ifndef CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
-    #define CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET    1
+    #define CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET    0
 #endif
 
 #ifndef CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE
@@ -87,7 +87,7 @@ typedef struct cellularModuleContext
     uint8_t dnsIndex;              /* DNS query current index. */
     char * pDnsUsrData;            /* DNS user data to store the result. */
 
-    #if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+    #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
         uint8_t pSocketBuffer[ CELLULAR_NUM_SOCKET_MAX ][ CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE ];
         uint32_t pSocketDataSize[ CELLULAR_NUM_SOCKET_MAX ];
     #endif  /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -100,10 +100,10 @@ typedef struct cellularModuleContext
 CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
                                             CellularSimCardState_t * pSimState );
 
-CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pCallbackContext,
-                                                  char * pLine,
-                                                  uint32_t lineLength,
-                                                  uint32_t * pUrcBufferLength );
+CellularPktStatus_t Cellular_BG96InputBufferCallback( void * pInputBufferCallbackContext,
+                                                      char * pBuffer,
+                                                      uint32_t bufferLength,
+                                                      uint32_t * pBufferLengthHandled );
 
 extern CellularAtParseTokenMap_t CellularUrcHandlerTable[];
 extern uint32_t CellularUrcHandlerTableSize;

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -49,6 +49,14 @@
 #define DATA_SEND_TIMEOUT_MS                       ( 50000UL )
 #define DATA_READ_TIMEOUT_MS                       ( 50000UL )
 
+#ifndef CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+    #define CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET    1
+#endif
+
+#ifndef CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE
+    #define CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE           ( 2048UL )
+#endif  /* CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE. */
+
 /**
  * @brief DNS query result.
  */
@@ -71,12 +79,19 @@ typedef void ( * CellularDnsResultEventCallback_t )( cellularModuleContext_t * p
 
 typedef struct cellularModuleContext
 {
+    PlatformMutex_t contextMutex;  /* Mutex for module context. */
+
     /* DNS related variables. */
-    PlatformMutex_t dnsQueryMutex; /* DNS query mutex to protect the following data. */
     QueueHandle_t pktDnsQueue;     /* DNS queue to receive the DNS query result. */
     uint8_t dnsResultNumber;       /* DNS query result number. */
     uint8_t dnsIndex;              /* DNS query current index. */
     char * pDnsUsrData;            /* DNS user data to store the result. */
+
+    #if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+        uint8_t pSocketBuffer[ CELLULAR_NUM_SOCKET_MAX ][ CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE ];
+        uint32_t pSocketDataSize[ CELLULAR_NUM_SOCKET_MAX ];
+    #endif  /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
+
     CellularDnsResultEventCallback_t dnsEventCallback;
     /* Forward declaration to declar the callback function prototype. */
     /* coverity[misra_c_2012_rule_1_1_violation]. */
@@ -84,6 +99,11 @@ typedef struct cellularModuleContext
 
 CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
                                             CellularSimCardState_t * pSimState );
+
+CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pCallbackContext,
+                                                  char * pLine,
+                                                  uint32_t lineLength,
+                                                  uint32_t * pUrcBufferLength );
 
 extern CellularAtParseTokenMap_t CellularUrcHandlerTable[];
 extern uint32_t CellularUrcHandlerTableSize;

--- a/source/cellular_bg96.h
+++ b/source/cellular_bg96.h
@@ -33,29 +33,29 @@
 /* *INDENT-ON* */
 
 /* AT Command timeout for PDN activation */
-#define PDN_ACTIVATION_PACKET_REQ_TIMEOUT_MS       ( 150000UL )
+#define PDN_ACTIVATION_PACKET_REQ_TIMEOUT_MS             ( 150000UL )
 
 /* AT Command timeout for PDN deactivation. */
-#define PDN_DEACTIVATION_PACKET_REQ_TIMEOUT_MS     ( 40000UL )
+#define PDN_DEACTIVATION_PACKET_REQ_TIMEOUT_MS           ( 40000UL )
 
 /* AT Command timeout for Socket connection */
-#define SOCKET_CONNECT_PACKET_REQ_TIMEOUT_MS       ( 150000UL )
+#define SOCKET_CONNECT_PACKET_REQ_TIMEOUT_MS             ( 150000UL )
 
-#define PACKET_REQ_TIMEOUT_MS                      ( 5000UL )
+#define PACKET_REQ_TIMEOUT_MS                            ( 5000UL )
 
 /* AT Command timeout for Socket disconnection */
-#define SOCKET_DISCONNECT_PACKET_REQ_TIMEOUT_MS    ( 12000UL )
+#define SOCKET_DISCONNECT_PACKET_REQ_TIMEOUT_MS          ( 12000UL )
 
-#define DATA_SEND_TIMEOUT_MS                       ( 50000UL )
-#define DATA_READ_TIMEOUT_MS                       ( 50000UL )
+#define DATA_SEND_TIMEOUT_MS                             ( 50000UL )
+#define DATA_READ_TIMEOUT_MS                             ( 50000UL )
 
 #ifndef CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
     #define CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET    0
 #endif
 
 #ifndef CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE
-    #define CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE           ( 2048UL )
-#endif  /* CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE. */
+    #define CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE    ( 2048UL )
+#endif /* CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE. */
 
 /**
  * @brief DNS query result.
@@ -79,18 +79,18 @@ typedef void ( * CellularDnsResultEventCallback_t )( cellularModuleContext_t * p
 
 typedef struct cellularModuleContext
 {
-    PlatformMutex_t contextMutex;  /* Mutex for module context. */
+    PlatformMutex_t contextMutex; /* Mutex for module context. */
 
     /* DNS related variables. */
-    QueueHandle_t pktDnsQueue;     /* DNS queue to receive the DNS query result. */
-    uint8_t dnsResultNumber;       /* DNS query result number. */
-    uint8_t dnsIndex;              /* DNS query current index. */
-    char * pDnsUsrData;            /* DNS user data to store the result. */
+    QueueHandle_t pktDnsQueue; /* DNS queue to receive the DNS query result. */
+    uint8_t dnsResultNumber;   /* DNS query result number. */
+    uint8_t dnsIndex;          /* DNS query current index. */
+    char * pDnsUsrData;        /* DNS user data to store the result. */
 
     #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
         uint8_t pSocketBuffer[ CELLULAR_NUM_SOCKET_MAX ][ CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE ];
         uint32_t pSocketDataSize[ CELLULAR_NUM_SOCKET_MAX ];
-    #endif  /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
+    #endif /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
 
     CellularDnsResultEventCallback_t dnsEventCallback;
     /* Forward declaration to declar the callback function prototype. */

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -2557,95 +2557,89 @@ CellularError_t Cellular_SocketRecv( CellularHandle_t cellularHandle,
             cellularStatus = CELLULAR_SOCKET_CLOSED;
         }
     }
-    else if( socketHandle->dataMode == CELLULAR_ACCESSMODE_BUFFER )
-    {
-        /* Update recvLen to maximum module length. */
-        if( CELLULAR_MAX_RECV_DATA_LEN <= bufferLength )
-        {
-            recvLen = ( uint32_t ) CELLULAR_MAX_RECV_DATA_LEN;
-        }
-
-        /* Update receive timeout to default timeout if not set with setsocketopt. */
-        if( socketHandle->recvTimeoutMs != 0U )
-        {
-            recvTimeout = socketHandle->recvTimeoutMs;
-        }
-
-        /* Form the AT command. */
-
-        /* The return value of snprintf is not used.
-         * The max length of the string is fixed and checked offline. */
-        /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE,
-                           "%s%ld,%ld", "AT+QIRD=", socketHandle->socketId, recvLen );
-        pktStatus = _Cellular_TimeoutAtcmdDataRecvRequestWithCallback( pContext,
-                                                                       atReqSocketRecv, recvTimeout, socketRecvDataPrefix, NULL );
-
-        if( pktStatus != CELLULAR_PKT_STATUS_OK )
-        {
-            /* Reset data handling parameters. */
-            LogError( ( "_Cellular_RecvData: Data Receive fail, pktStatus: %d", pktStatus ) );
-            cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
-        }
-    }
     else
     {
-        #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
+        if( socketHandle->dataMode == CELLULAR_ACCESSMODE_BUFFER )
         {
-            if( socketHandle->dataMode == CELLULAR_ACCESSMODE_DIRECT_PUSH )
+            /* Update recvLen to maximum module length. */
+            if( CELLULAR_MAX_RECV_DATA_LEN <= bufferLength )
             {
-                /* Copy from the buffer. */
-                cellularModuleContext_t * pModuleContext = NULL;
-                cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+                recvLen = ( uint32_t ) CELLULAR_MAX_RECV_DATA_LEN;
+            }
 
-                if( cellularStatus != CELLULAR_SUCCESS )
-                {
-                    pktStatus = CELLULAR_PKT_STATUS_INVALID_HANDLE;
-                }
-                else
-                {
-                    uint8_t *pSocketDataPtr;
-                    uint32_t socketDataLength;
+            /* Update receive timeout to default timeout if not set with setsocketopt. */
+            if( socketHandle->recvTimeoutMs != 0U )
+            {
+                recvTimeout = socketHandle->recvTimeoutMs;
+            }
 
-                    PlatformMutex_Lock( &pModuleContext->contextMutex );
+            /* Form the AT command. */
 
-                    pSocketDataPtr = &pModuleContext->pSocketBuffer[ socketHandle->socketId ];
-                    socketDataLength = pModuleContext->pSocketDataSize[ socketHandle->socketId ];
+            /* The return value of snprintf is not used.
+             * The max length of the string is fixed and checked offline. */
+            /* coverity[misra_c_2012_rule_21_6_violation]. */
+            ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_TYPICAL_MAX_SIZE,
+                               "%s%ld,%ld", "AT+QIRD=", socketHandle->socketId, recvLen );
+            pktStatus = _Cellular_TimeoutAtcmdDataRecvRequestWithCallback( pContext,
+                                                                           atReqSocketRecv, recvTimeout, socketRecvDataPrefix, NULL );
 
-                    if( bufferLength > socketDataLength )
-                    {
-                        *pReceivedDataLength = socketDataLength;
-                    }
-                    else
-                    {
-                        *pReceivedDataLength = bufferLength;
-                    }
+            if( pktStatus != CELLULAR_PKT_STATUS_OK )
+            {
+                /* Reset data handling parameters. */
+                LogError( ( "_Cellular_RecvData: Data Receive fail, pktStatus: %d", pktStatus ) );
+                cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+            }
+        }
+        #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
+        else if( socketHandle->dataMode == CELLULAR_ACCESSMODE_DIRECT_PUSH )
+        {
+            /* Socket data is returned in URC with direct push mode and store in
+             * in the buffer of module context. Copy the data from the buffer and
+             * decrease the data length of the buffer. */
+            cellularModuleContext_t * pModuleContext = NULL;
+            uint8_t *pSocketDataPtr;
+            uint32_t socketDataLength;
 
-                    /* Copy the data to the socket buffer. */
-                    memcpy( pBuffer, pSocketDataPtr, *pReceivedDataLength );
+            cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
 
-                    /* Garbage collection. Decrease the size of data in socket buffer
-                     * and move the data to start of socket buffer. */
-                    pModuleContext->pSocketDataSize[ socketHandle->socketId ] -= *pReceivedDataLength;
-                    memmove( pSocketDataPtr, &pSocketDataPtr[ *pReceivedDataLength ], ( socketDataLength - *pReceivedDataLength ) );
-
-                    PlatformMutex_Unlock( &pModuleContext->contextMutex );
-                }
+            if( cellularStatus != CELLULAR_SUCCESS )
+            {
+                pktStatus = CELLULAR_PKT_STATUS_INVALID_HANDLE;
             }
             else
             {
-                LogError( ( "storeAccessModeAndAddress, Access mode not supported %d.",
-                            socketHandle->dataMode ) );
-                cellularStatus = CELLULAR_UNSUPPORTED;
+                PlatformMutex_Lock( &pModuleContext->contextMutex );
+
+                pSocketDataPtr = ( uint8_t * )&pModuleContext->pSocketBuffer[ socketHandle->socketId ];
+                socketDataLength = pModuleContext->pSocketDataSize[ socketHandle->socketId ];
+
+                if( bufferLength > socketDataLength )
+                {
+                    *pReceivedDataLength = socketDataLength;
+                }
+                else
+                {
+                    *pReceivedDataLength = bufferLength;
+                }
+
+                /* Copy the data to the socket buffer. */
+                memcpy( pBuffer, pSocketDataPtr, *pReceivedDataLength );
+
+                /* Garbage collection. Decrease the size of data in socket buffer
+                 * and move the data to start of socket buffer. */
+                pModuleContext->pSocketDataSize[ socketHandle->socketId ] -= *pReceivedDataLength;
+                memmove( pSocketDataPtr, &pSocketDataPtr[ *pReceivedDataLength ], ( socketDataLength - *pReceivedDataLength ) );
+
+                PlatformMutex_Unlock( &pModuleContext->contextMutex );
             }
         }
-        #else   /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
+        #endif   /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
+        else
         {
             LogError( ( "storeAccessModeAndAddress, Access mode not supported %d.",
                         socketHandle->dataMode ) );
             cellularStatus = CELLULAR_UNSUPPORTED;
         }
-        #endif  /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
     }
 
     return cellularStatus;

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -2590,7 +2590,7 @@ CellularError_t Cellular_SocketRecv( CellularHandle_t cellularHandle,
     }
     else
     {
-        #if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+        #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
         {
             if( socketHandle->dataMode == CELLULAR_ACCESSMODE_DIRECT_PUSH )
             {

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -2538,6 +2538,11 @@ CellularError_t Cellular_SocketRecv( CellularHandle_t cellularHandle,
         LogError( ( "Cellular_SocketRecv: Invalid socket handle." ) );
         cellularStatus = CELLULAR_INVALID_HANDLE;
     }
+    else if( socketHandle->socketId >= CELLULAR_NUM_SOCKET_MAX )
+    {
+        LogError( ( "Cellular_SocketRecv: Invalid socket index." ) );
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
     else if( ( pBuffer == NULL ) || ( pReceivedDataLength == NULL ) || ( bufferLength == 0U ) )
     {
         LogError( ( "Cellular_SocketRecv: Bad input Param." ) );

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -40,8 +40,8 @@
 
 /*-----------------------------------------------------------*/
 
-#define CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX        "+QIURC: \"recv\","
-#define CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_LEN    15
+#define CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX            "+QIURC: \"recv\","
+#define CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_LEN        15
 
 /* The length for the string "+QIURC: \"recv\",<socket_index:1>,<socket_size:1~4>\r\n". */
 #define CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN    24
@@ -68,7 +68,7 @@ static CellularPktStatus_t prvParseDirectPushURCPrefix( char * pBuffer,
                                                         uint32_t * pSocketIndex,
                                                         uint32_t * pDataLength );
 static CellularPktStatus_t prvStoreDirectPushSocketData( CellularContext_t * pContext,
-                                                         char *pBuffer,
+                                                         char * pBuffer,
                                                          uint32_t prefixLength,
                                                          uint32_t socketIndex,
                                                          uint32_t dataLength );
@@ -766,12 +766,13 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
-    /**
-     * @brief Extract information from direct push socket URC.
-     * In the following example, prefix length is 20, socket index is 0 and data length is 4.
-     * +QIURC: "recv",0,4\r\n
-     * test\r\n
-     */
+
+/**
+ * @brief Extract information from direct push socket URC.
+ * In the following example, prefix length is 20, socket index is 0 and data length is 4.
+ * +QIURC: "recv",0,4\r\n
+ * test\r\n
+ */
     static CellularPktStatus_t prvParseDirectPushURCPrefix( char * pBuffer,
                                                             uint32_t bufferLength,
                                                             uint32_t * pPrefixLength,
@@ -779,7 +780,7 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
                                                             uint32_t * pDataLength )
     {
         char pLocaLine[ CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN ];
-        char *pLocalLinePtr = pLocaLine;
+        char * pLocalLinePtr = pLocaLine;
         char * pToken;
         CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
         CellularATError_t atCoreStatus;
@@ -809,19 +810,22 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
         else
         {
             strncpy( pLocalLinePtr, pBuffer, i );
-            pLocalLinePtr[ i ] = '\0';  /* Replace the change line '\r' with '\0'. */
-            *pPrefixLength = i + 2;       /* Add 2 to the length to include "\r\n". */
+            pLocalLinePtr[ i ] = '\0'; /* Replace the change line '\r' with '\0'. */
+            *pPrefixLength = i + 2;    /* Add 2 to the length to include "\r\n". */
 
             /* Get the socket index. Socket index is the second token. */
             atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+
             if( atCoreStatus == CELLULAR_AT_SUCCESS )
             {
                 atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
             }
+
             if( atCoreStatus == CELLULAR_AT_SUCCESS )
             {
                 atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
             }
+
             if( atCoreStatus == CELLULAR_AT_SUCCESS )
             {
                 if( ( tempValue >= 0 ) &&
@@ -841,10 +845,12 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
             {
                 atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
             }
+
             if( atCoreStatus == CELLULAR_AT_SUCCESS )
             {
                 atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
             }
+
             if( atCoreStatus == CELLULAR_AT_SUCCESS )
             {
                 if( tempValue >= 0 )
@@ -864,20 +870,21 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
 
         return pktStatus;
     }
-#endif
+#endif /* if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
-    /**
-     * @brief Copy socket data in URC to the socekt buffer in module context.
-     */
+
+/**
+ * @brief Copy socket data in URC to the socekt buffer in module context.
+ */
     static CellularPktStatus_t prvStoreDirectPushSocketData( CellularContext_t * pContext,
-                                                             char *pBuffer,
+                                                             char * pBuffer,
                                                              uint32_t prefixLength,
                                                              uint32_t socketIndex,
                                                              uint32_t dataLength )
     {
-        uint8_t *pDataPtr = NULL;
+        uint8_t * pDataPtr = NULL;
         uint32_t socketDataSize;
         CellularSocketContext_t * pSocketData;
         cellularModuleContext_t * pModuleContext = NULL;
@@ -885,6 +892,7 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
         CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
 
         pSocketData = _Cellular_GetSocketData( pContext, socketIndex );
+
         if( pSocketData == NULL )
         {
             /* Invalid socket index. */
@@ -900,6 +908,7 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
         else
         {
             cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+
             if( cellularStatus == CELLULAR_SUCCESS )
             {
                 /* Copy the data to the socket buffer. */
@@ -921,7 +930,7 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
                 else
                 {
                     LogError( ( "Cellular_BG96InputBufferCallback : drop socket %u packet. buffer left %u is not enough for %u.",
-                        socketIndex, ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ), dataLength ) );
+                                socketIndex, ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ), dataLength ) );
                     pktStatus = CELLULAR_PKT_STATUS_FAILURE;
                 }
             }
@@ -932,9 +941,10 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
                 pktStatus = CELLULAR_PKT_STATUS_FAILURE;
             }
         }
+
         return pktStatus;
     }
-#endif
+#endif /* if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 ) */
 /*-----------------------------------------------------------*/
 
 /* Cellular common prototype. */
@@ -1005,7 +1015,7 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
         uint32_t socketIndex;
         uint32_t dataLength;
         uint32_t prefixLength;
-        const uint32_t suffixLength = 2;    /* The "\r\n" after the data stream. */
+        const uint32_t suffixLength = 2; /* The "\r\n" after the data stream. */
         CellularPktStatus_t pktStatus;
 
         if( pInputBufferCallbackContext == NULL )
@@ -1053,6 +1063,7 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
             {
                 /* Store the socket URC to a buffer in module context. */
                 pktStatus = prvStoreDirectPushSocketData( pContext, pBuffer, prefixLength, socketIndex, dataLength );
+
                 if( pktStatus == CELLULAR_PKT_STATUS_OK )
                 {
                     /* Returns the complenet URC data length. Pktio thread will process
@@ -1064,5 +1075,5 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
 
         return pktStatus;
     }
-#endif
+#endif /* if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 ) */
 /*-----------------------------------------------------------*/

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -814,7 +814,7 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
 
 /*-----------------------------------------------------------*/
 
-#if CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET
+#if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
 CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext,
                                                   char * pBuffer,
                                                   uint32_t bufferLength,

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -815,12 +815,12 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
-CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext,
-                                                  char * pBuffer,
-                                                  uint32_t bufferLength,
-                                                  uint32_t * pUrcDataLength )
+CellularPktStatus_t Cellular_BG96InputBufferCallback( void * pInputBufferCallbackContext,
+                                                      char * pBuffer,
+                                                      uint32_t bufferLength,
+                                                      uint32_t * pBufferLengthHandled )
 {
-    CellularContext_t * pContext = ( CellularContext_t * ) pUrcDataCallbackContext;
+    CellularContext_t * pContext = ( CellularContext_t * ) pInputBufferCallbackContext;
     cellularModuleContext_t * pModuleContext = NULL;
     char pLocaLine[ CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN ];
     char *pLocalLinePtr = pLocaLine;
@@ -835,19 +835,19 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
     int32_t tempValue;
     uint32_t socketIndex;
 
-    if( pUrcDataCallbackContext == NULL )
+    if( pInputBufferCallbackContext == NULL )
     {
-        LogError( ( "Cellular_BG96UrcDataCallback : pUrcDataCallbackContext is NULL." ) );
+        LogError( ( "Cellular_BG96InputBufferCallback : pInputBufferCallbackContext is NULL." ) );
         pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
     }
     else if( pBuffer == NULL )
     {
-        LogError( ( "Cellular_BG96UrcDataCallback : pBuffer is NULL." ) );
+        LogError( ( "Cellular_BG96InputBufferCallback : pBuffer is NULL." ) );
         pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
     }
-    else if( pUrcDataLength == NULL )
+    else if( pBufferLengthHandled == NULL )
     {
-        LogError( ( "Cellular_BG96UrcDataCallback : pUrcDataLength is NULL." ) );
+        LogError( ( "Cellular_BG96InputBufferCallback : pBufferLengthHandled is NULL." ) );
         pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
     }
     else if( bufferLength < CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_LEN )
@@ -908,7 +908,7 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
                 }
                 else
                 {
-                    LogError( ( "Cellular_BG96UrcDataCallback : Error processing in Socket index. token %s.", pToken ) );
+                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in Socket index. token %s.", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -930,7 +930,7 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
                 }
                 else
                 {
-                    LogError( ( "Cellular_BG96UrcDataCallback : Error processing in dataLength. token %s.", pToken ) );
+                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in dataLength. token %s.", pToken ) );
                     atCoreStatus = CELLULAR_AT_ERROR;
                 }
             }
@@ -957,13 +957,13 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
                     if( pSocketData == NULL )
                     {
                         /* Invalid socket index. */
-                        LogError( ( "Cellular_BG96UrcDataCallback : Invalid socket index %u.", socketIndex ) );
+                        LogError( ( "Cellular_BG96InputBufferCallback : Invalid socket index %u.", socketIndex ) );
                     }
                     else if( pSocketData->socketState != SOCKETSTATE_CONNECTED )
                     {
                         /* Invalid socket state. This could be socket is not closed before
                          * the cellular interface is inited. Return handled to pktio and discard the data. */
-                        LogWarn( ( "Cellular_BG96UrcDataCallback : Invalid socket state %u. Discard packet.", socketIndex ) );
+                        LogWarn( ( "Cellular_BG96InputBufferCallback : Invalid socket state %u. Discard packet.", socketIndex ) );
                     }
                     else
                     {
@@ -972,7 +972,7 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
                         {
                             /* Returns the complenet URC data length. Pktio thread will process
                              * the data after. */
-                            *pUrcDataLength = prefixLength + dataLength + suffixLength;
+                            *pBufferLengthHandled = prefixLength + dataLength + suffixLength;
 
                             /* Copy the data to the socket buffer. */
                             PlatformMutex_Lock( &pModuleContext->contextMutex );
@@ -992,14 +992,14 @@ CellularPktStatus_t Cellular_BG96UrcDataCallback( void * pUrcDataCallbackContext
                             }
                             else
                             {
-                                LogError( ( "Cellular_BG96UrcDataCallback : drop socket %u packet. buffer left %u is not enough for %u.",
+                                LogError( ( "Cellular_BG96InputBufferCallback : drop socket %u packet. buffer left %u is not enough for %u.",
                                     socketIndex, ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ), dataLength ) );
                             }
                         }
                         else
                         {
                             /* Get the module context error. */
-                            LogError( ( "Cellular_BG96UrcDataCallback : get module context failed." ) );
+                            LogError( ( "Cellular_BG96InputBufferCallback : get module context failed." ) );
                             pktStatus = CELLULAR_PKT_STATUS_FAILURE;
                         }
                     }

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -62,6 +62,16 @@ static void _Cellular_ProcessSimstat( CellularContext_t * pContext,
                                       char * pInputLine );
 static void _Cellular_ProcessIndication( CellularContext_t * pContext,
                                          char * pInputLine );
+static CellularPktStatus_t prvParseDirectPushURCPrefix( char * pBuffer,
+                                                        uint32_t bufferLength,
+                                                        uint32_t * pPrefixLength,
+                                                        uint32_t * pSocketIndex,
+                                                        uint32_t * pDataLength );
+static CellularPktStatus_t prvStoreDirectPushSocketData( CellularContext_t * pContext,
+                                                         char *pBuffer,
+                                                         uint32_t prefixLength,
+                                                         uint32_t socketIndex,
+                                                         uint32_t dataLength );
 
 /*-----------------------------------------------------------*/
 
@@ -755,6 +765,178 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
+#if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
+    /**
+     * @brief Extract information from direct push socket URC.
+     * In the following example, prefix length is 20, socket index is 0 and data length is 4.
+     * +QIURC: "recv",0,4\r\n
+     * test\r\n
+     */
+    static CellularPktStatus_t prvParseDirectPushURCPrefix( char * pBuffer,
+                                                            uint32_t bufferLength,
+                                                            uint32_t * pPrefixLength,
+                                                            uint32_t * pSocketIndex,
+                                                            uint32_t * pDataLength )
+    {
+        char pLocaLine[ CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN ];
+        char *pLocalLinePtr = pLocaLine;
+        char * pToken;
+        CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+        CellularATError_t atCoreStatus;
+        int32_t tempValue;
+        uint32_t i;
+
+        /* Find the first complete line in the buffer. */
+        for( i = 0; i < bufferLength; i++ )
+        {
+            if( ( pBuffer[ i ] == '\r' ) || ( pBuffer[ i ] == '\n' ) )
+            {
+                break;
+            }
+        }
+
+        /* A complete line is received in the buffer. */
+        if( i > CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN )
+        {
+            /* The line length is longer than expected. */
+            pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
+        }
+        else if( i >= bufferLength )
+        {
+            /* New line is not found. */
+            pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
+        }
+        else
+        {
+            strncpy( pLocalLinePtr, pBuffer, i );
+            pLocalLinePtr[ i ] = '\0';  /* Replace the change line '\r' with '\0'. */
+            *pPrefixLength = i + 2;       /* Add 2 to the length to include "\r\n". */
+
+            /* Get the socket index. Socket index is the second token. */
+            atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+            }
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
+            }
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                if( ( tempValue >= 0 ) &&
+                    ( tempValue < ( int32_t ) CELLULAR_NUM_SOCKET_MAX ) )
+                {
+                    *pSocketIndex = ( uint32_t ) tempValue;
+                }
+                else
+                {
+                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in Socket index. token %s.", pToken ) );
+                    atCoreStatus = CELLULAR_AT_ERROR;
+                }
+            }
+
+            /* Get the data length. Data length is the third token. */
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+            }
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
+            }
+            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            {
+                if( tempValue >= 0 )
+                {
+                    *pDataLength = ( uint32_t ) tempValue;
+                }
+                else
+                {
+                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in dataLength. token %s.", pToken ) );
+                    atCoreStatus = CELLULAR_AT_ERROR;
+                }
+            }
+
+            /* Translate atCoreStatus to packet status to indicate error. */
+            pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+        }
+
+        return pktStatus;
+    }
+#endif
+/*-----------------------------------------------------------*/
+
+#if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
+    /**
+     * @brief Copy socket data in URC to the socekt buffer in module context.
+     */
+    static CellularPktStatus_t prvStoreDirectPushSocketData( CellularContext_t * pContext,
+                                                             char *pBuffer,
+                                                             uint32_t prefixLength,
+                                                             uint32_t socketIndex,
+                                                             uint32_t dataLength )
+    {
+        uint8_t *pDataPtr = NULL;
+        uint32_t socketDataSize;
+        CellularSocketContext_t * pSocketData;
+        cellularModuleContext_t * pModuleContext = NULL;
+        CellularError_t cellularStatus;
+        CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+
+        pSocketData = _Cellular_GetSocketData( pContext, socketIndex );
+        if( pSocketData == NULL )
+        {
+            /* Invalid socket index. */
+            LogError( ( "Cellular_BG96InputBufferCallback : Invalid socket index %u.", socketIndex ) );
+            pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+        }
+        else if( pSocketData->socketState != SOCKETSTATE_CONNECTED )
+        {
+            /* Invalid socket state. This could be socket is not closed before
+             * the cellular interface is inited. Return handled to pktio and discard the data. */
+            LogWarn( ( "Cellular_BG96InputBufferCallback : Invalid socket state %u. Discard packet.", socketIndex ) );
+        }
+        else
+        {
+            cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
+            if( cellularStatus == CELLULAR_SUCCESS )
+            {
+                /* Copy the data to the socket buffer. */
+                PlatformMutex_Lock( &pModuleContext->contextMutex );
+                pDataPtr = pModuleContext->pSocketBuffer[ socketIndex ];
+                socketDataSize = pModuleContext->pSocketDataSize[ socketIndex ];
+
+                /* Check empty socket buffer left. */
+                if( ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ) > dataLength )
+                {
+                    memcpy( &pDataPtr[ socketDataSize ], &pBuffer[ prefixLength ], dataLength );
+                    pModuleContext->pSocketDataSize[ socketIndex ] += dataLength;
+
+                    PlatformMutex_Unlock( &pModuleContext->contextMutex );
+
+                    /* Notify upper layer about data received. */
+                    _informDataReadyToUpperLayer( pSocketData );
+                }
+                else
+                {
+                    LogError( ( "Cellular_BG96InputBufferCallback : drop socket %u packet. buffer left %u is not enough for %u.",
+                        socketIndex, ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ), dataLength ) );
+                    pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+                }
+            }
+            else
+            {
+                /* Get the module context error. */
+                LogError( ( "Cellular_BG96InputBufferCallback : get module context failed." ) );
+                pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+            }
+        }
+        return pktStatus;
+    }
+#endif
+/*-----------------------------------------------------------*/
+
 /* Cellular common prototype. */
 /* coverity[misra_c_2012_rule_8_13_violation] */
 CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
@@ -811,204 +993,76 @@ CellularPktStatus_t _Cellular_ParseSimstat( char * pInputStr,
 
     return pktStatus;
 }
-
 /*-----------------------------------------------------------*/
 
 #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
-CellularPktStatus_t Cellular_BG96InputBufferCallback( void * pInputBufferCallbackContext,
-                                                      char * pBuffer,
-                                                      uint32_t bufferLength,
-                                                      uint32_t * pBufferLengthHandled )
-{
-    CellularContext_t * pContext = ( CellularContext_t * ) pInputBufferCallbackContext;
-    cellularModuleContext_t * pModuleContext = NULL;
-    char pLocaLine[ CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN ];
-    char *pLocalLinePtr = pLocaLine;
-    uint32_t dataLength;
-    char * pTempLine = pBuffer;
-    char * pToken;
-    uint32_t i = 0;
-    uint32_t prefixLength;
-    uint32_t suffixLength = 2;
-    CellularPktStatus_t pktStatus;
-    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
-    int32_t tempValue;
-    uint32_t socketIndex;
+    CellularPktStatus_t Cellular_BG96InputBufferCallback( void * pInputBufferCallbackContext,
+                                                          char * pBuffer,
+                                                          uint32_t bufferLength,
+                                                          uint32_t * pBufferLengthHandled )
+    {
+        CellularContext_t * pContext = ( CellularContext_t * ) pInputBufferCallbackContext;
+        uint32_t socketIndex;
+        uint32_t dataLength;
+        uint32_t prefixLength;
+        const uint32_t suffixLength = 2;    /* The "\r\n" after the data stream. */
+        CellularPktStatus_t pktStatus;
 
-    if( pInputBufferCallbackContext == NULL )
-    {
-        LogError( ( "Cellular_BG96InputBufferCallback : pInputBufferCallbackContext is NULL." ) );
-        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-    }
-    else if( pBuffer == NULL )
-    {
-        LogError( ( "Cellular_BG96InputBufferCallback : pBuffer is NULL." ) );
-        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-    }
-    else if( pBufferLengthHandled == NULL )
-    {
-        LogError( ( "Cellular_BG96InputBufferCallback : pBufferLengthHandled is NULL." ) );
-        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
-    }
-    else if( bufferLength < CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_LEN )
-    {
-        /* Return CELLULAR_PKT_STATUS_PREFIX_MISMATCH if there is not enough information.
-         * pktio thread will continue to process the buffer. */
-        pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
-    }
-    else if( strstr( pBuffer, CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX ) == NULL )
-    {
-        /* Return CELLULAR_PKT_STATUS_PREFIX_MISMATCH as the prefix is not match. */
-        pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
-    }
-    else
-    {
-        /* Find the first complete line in the buffer. */
-        for( i = 0; i < bufferLength; i++ )
+        if( pInputBufferCallbackContext == NULL )
         {
-            if( ( pTempLine[ i ] == '\r' ) || ( pTempLine[ i ] == '\n' ) )
-            {
-                break;
-            }
+            LogError( ( "Cellular_BG96InputBufferCallback : pInputBufferCallbackContext is NULL." ) );
+            pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
         }
-
-        /* A complete line is received in the buffer. */
-        if( i > CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_MAX_LEN )
+        else if( pBuffer == NULL )
         {
-            /* The line length is longer than expected. */
-            pktStatus = CELLULAR_PKT_STATUS_INVALID_DATA;
+            LogError( ( "Cellular_BG96InputBufferCallback : pBuffer is NULL." ) );
+            pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
         }
-        else if( i >= bufferLength )
+        else if( pBufferLengthHandled == NULL )
         {
-            /* New line is not found. */
-            pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
+            LogError( ( "Cellular_BG96InputBufferCallback : pBufferLengthHandled is NULL." ) );
+            pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
+        }
+        else if( bufferLength < CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX_LEN )
+        {
+            /* Return CELLULAR_PKT_STATUS_PREFIX_MISMATCH if there is not enough information.
+             * pktio thread will continue to process the buffer. */
+            pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
+        }
+        else if( strstr( pBuffer, CELLULAR_BG96_DIRECT_PUSH_SOCKET_URC_PFREFIX ) == NULL )
+        {
+            /* Return CELLULAR_PKT_STATUS_PREFIX_MISMATCH as the prefix is not match. */
+            pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
         }
         else
         {
-            strncpy( pLocalLinePtr, pTempLine, i );
-            pLocalLinePtr[ i ] = '\0';  /* Replace the change line '\r' with '\0'. */
-            prefixLength = i + 2;       /* Add 2 to the length to include "\r\n". */
+            pktStatus = prvParseDirectPushURCPrefix( pBuffer, bufferLength, &prefixLength, &socketIndex, &dataLength );
 
-            /* Get the socket index. Socket index is the second token. */
-            atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+                /* Error during parse the direct push URC. */
             }
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            else if( ( prefixLength + dataLength + suffixLength ) > bufferLength )
             {
-                atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
+                /* Check if the complete data is received. If not, returns CELLULAR_PKT_STATUS_SIZE_MISMATCH
+                 * to stop pktio from further process the data. This function will be called
+                 * again with more data. */
+                pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
             }
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            else
             {
-                if( ( tempValue >= 0 ) &&
-                    ( tempValue < ( int32_t ) CELLULAR_NUM_SOCKET_MAX ) )
+                /* Store the socket URC to a buffer in module context. */
+                pktStatus = prvStoreDirectPushSocketData( pContext, pBuffer, prefixLength, socketIndex, dataLength );
+                if( pktStatus == CELLULAR_PKT_STATUS_OK )
                 {
-                    socketIndex = ( uint32_t ) tempValue;
-                }
-                else
-                {
-                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in Socket index. token %s.", pToken ) );
-                    atCoreStatus = CELLULAR_AT_ERROR;
-                }
-            }
-
-            /* Get the data length. Data length is the third token. */
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
-            {
-                atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
-            }
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
-            {
-                atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
-            }
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
-            {
-                if( tempValue >= 0 )
-                {
-                    dataLength = ( uint32_t ) tempValue;
-                }
-                else
-                {
-                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in dataLength. token %s.", pToken ) );
-                    atCoreStatus = CELLULAR_AT_ERROR;
-                }
-            }
-
-            /* Translate atCoreStatus to packet status. */
-            pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
-
-            if( pktStatus == CELLULAR_PKT_STATUS_OK )
-            {
-                /* Check if the complete buffer is received. */
-                if( ( prefixLength + dataLength + suffixLength ) > bufferLength )
-                {
-                    pktStatus = CELLULAR_PKT_STATUS_SIZE_MISMATCH;
-                }
-                else
-                {
-                    uint8_t *pDataPtr = NULL;
-                    uint32_t socketDataSize;
-                    CellularSocketContext_t * pSocketData;
-                    cellularModuleContext_t * pModuleContext = NULL;
-                    CellularError_t cellularStatus;
-
-                    pSocketData = _Cellular_GetSocketData( pContext, socketIndex );
-                    if( pSocketData == NULL )
-                    {
-                        /* Invalid socket index. */
-                        LogError( ( "Cellular_BG96InputBufferCallback : Invalid socket index %u.", socketIndex ) );
-                    }
-                    else if( pSocketData->socketState != SOCKETSTATE_CONNECTED )
-                    {
-                        /* Invalid socket state. This could be socket is not closed before
-                         * the cellular interface is inited. Return handled to pktio and discard the data. */
-                        LogWarn( ( "Cellular_BG96InputBufferCallback : Invalid socket state %u. Discard packet.", socketIndex ) );
-                    }
-                    else
-                    {
-                        cellularStatus = _Cellular_GetModuleContext( pContext, ( void ** ) &pModuleContext );
-                        if( cellularStatus == CELLULAR_SUCCESS )
-                        {
-                            /* Returns the complenet URC data length. Pktio thread will process
-                             * the data after. */
-                            *pBufferLengthHandled = prefixLength + dataLength + suffixLength;
-
-                            /* Copy the data to the socket buffer. */
-                            PlatformMutex_Lock( &pModuleContext->contextMutex );
-                            pDataPtr = pModuleContext->pSocketBuffer[ socketIndex ];
-                            socketDataSize = pModuleContext->pSocketDataSize[ socketIndex ];
-
-                            /* Check empty socket buffer left. */
-                            if( ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ) > dataLength )
-                            {
-                                memcpy( &pDataPtr[ socketDataSize ], &pBuffer[ prefixLength ], dataLength );
-                                pModuleContext->pSocketDataSize[ socketIndex ] += dataLength;
-
-                                PlatformMutex_Unlock( &pModuleContext->contextMutex );
-
-                                /* Notify upper layer about data received. */
-                                _informDataReadyToUpperLayer( pSocketData );
-                            }
-                            else
-                            {
-                                LogError( ( "Cellular_BG96InputBufferCallback : drop socket %u packet. buffer left %u is not enough for %u.",
-                                    socketIndex, ( CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE - socketDataSize ), dataLength ) );
-                            }
-                        }
-                        else
-                        {
-                            /* Get the module context error. */
-                            LogError( ( "Cellular_BG96InputBufferCallback : get module context failed." ) );
-                            pktStatus = CELLULAR_PKT_STATUS_FAILURE;
-                        }
-                    }
+                    /* Returns the complenet URC data length. Pktio thread will process
+                     * the data after. */
+                    *pBufferLengthHandled = prefixLength + dataLength + suffixLength;
                 }
             }
         }
-    }
 
-    return pktStatus;
-}
+        return pktStatus;
+    }
 #endif
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Add BG96 support direct push socket.

This commit provides an example of input buffer callback in this PR https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/pull/137.

Socket data is returned in the URC with direct access mode. To support this feature, the port make use of the input buffer callback to handle the binary data in URC.
In the following example, the socket data "test" will be stored in the buffer in module context. User of this port can retrieve the data with Cellular_SocketRecv later.
```
+QIURC: "recv",0,4
test
```

Compare to buffer access mode, the port will allocate an extra buffer per socket to store the socket data. This useful if developers want to configure the buffer size in MCU instead of relying on the buffer size in modem.

Description
-----------
* This mode doesn't make use of the buffer in cellular modem. The socket data received is directly pushed through URC code. Extra buffer for socket will be required if enabled. Default buffer size is 2048 and can be configured with **CELLULAR_BG96_DIRECT_PUSH_SOCKET_BUFFER_SIZE**.
* Define **CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET** in cellular_config.h to enable this function. Default is disabled.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
