### PR TITLE
Fix input buffer callback for buffer access mode

### DIFF
--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -840,32 +840,40 @@ static void _Cellular_ProcessModemRdy( CellularContext_t * pContext,
                 }
             }
 
-            /* Get the data length. Data length is the third token. */
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            if( pLocalLinePtr[ 0 ] == '\0' )
             {
-                atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
+                /* The third token is empty. This is a buffer access mode URC. */
+                pktStatus = CELLULAR_PKT_STATUS_PREFIX_MISMATCH;
             }
-
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
+            else
             {
-                atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
-            }
-
-            if( atCoreStatus == CELLULAR_AT_SUCCESS )
-            {
-                if( tempValue >= 0 )
+                /* Get the data length. Data length is the third token. */
+                if( atCoreStatus == CELLULAR_AT_SUCCESS )
                 {
-                    *pDataLength = ( uint32_t ) tempValue;
+                    atCoreStatus = Cellular_ATGetNextTok( &pLocalLinePtr, &pToken );
                 }
-                else
-                {
-                    LogError( ( "Cellular_BG96InputBufferCallback : Error processing in dataLength. token %s.", pToken ) );
-                    atCoreStatus = CELLULAR_AT_ERROR;
-                }
-            }
 
-            /* Translate atCoreStatus to packet status to indicate error. */
-            pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+                if( atCoreStatus == CELLULAR_AT_SUCCESS )
+                {
+                    atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
+                }
+
+                if( atCoreStatus == CELLULAR_AT_SUCCESS )
+                {
+                    if( tempValue >= 0 )
+                    {
+                        *pDataLength = ( uint32_t ) tempValue;
+                    }
+                    else
+                    {
+                        LogError( ( "Cellular_BG96InputBufferCallback : Error processing in dataLength. token %s.", pToken ) );
+                        atCoreStatus = CELLULAR_AT_ERROR;
+                    }
+                }
+
+                /* Translate atCoreStatus to packet status to indicate error. */
+                pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+            }
         }
 
         return pktStatus;


### PR DESCRIPTION


<!--- Title -->

Description
-----------
* To support both mode at the same time, update the input buffer callback to distinguish URC for buffer access mode.

Test Steps
-----------
Enable direct push mode support by setting `CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET` to 1.
Run the MQTT demo with buffer access mode.

Before, there will be following log.
```
0 39 [CellularConnec] >>>  Cellular SIM okay  <<<
>>>  Cellular GetServiceStatus failed 0, ps registration status 0  <<<
1 1185 [CellularConnec] >>>  Cellular module registered  <<<
>>>  Cellular module registered, IP address 10.196.179.17  <<<
2 1194 [CellularConnec] [INFO] [CellularsimBG96] [prvMQTTDemoTask:538] ---------STARTING DEMO---------

3 1194 [CellularConnec] [INFO] [CellularsimBG96] [prvConnectToServerWithBackoffRetries:702] Creating a TLS connection to
a2zzppv7s4siea-ats.iot.us-west-2.amazonaws.com:8883.

4 1747 [Cellular_Threa] [ERROR] [CellularLib] [_handleCallbackResult:886] Input buffer callback returns error 6. Clean th
e read buffer.

```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
