### PR TITLE
Fix BG96 AT+QCSQ command response parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 This repository provides the reference implementation as cellular module ports for [Quectel BG96](https://www.quectel.com/product/lte-bg96-cat-m1-nb1-egprs/). This repository should be used with [FreeRTOS-Cellular-Interface](https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface). See [FreeRTOS-Cellular-Interface README](https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/README.md) for more details.
 
+The BG96 port implemenation follows [Quectel_BG96_AT_Commands_Manual_V2.3](https://www.quectel.com/download/quectel_bg96_at_commands_manual_v2-3).
+The firmware version of BG96 can be acquired with the following AT commands:
+* ATI
+* AT+QGMR
+
+If the firmware version is not supported in the AT command document, you may contact
+Quectel for a firmware update.
+
 ## Use Case
 
 There is also an use case at [MQTT_Mutual_Auth_Demo_with_BG96](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/FreeRTOS_Cellular_Interface_Windows_Simulator/MQTT_Mutual_Auth_Demo_with_BG96) as a demonstration to run BG96 with FreeRTOS Windows Simulator.

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -68,7 +68,7 @@ uint32_t CellularSrcTokenSuccessTableSize = sizeof( CellularSrcTokenSuccessTable
 /* FreeRTOS Cellular Common Library porting interface. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
 const char * CellularUrcTokenWoPrefixTable[] =
-{ "NORMAL POWER DOWN", "PSM POWER DOWN", "RDY" };
+{ "POWERED DOWN", "PSM POWER DOWN", "RDY" };
 /* FreeRTOS Cellular Common Library porting interface. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
 uint32_t CellularUrcTokenWoPrefixTableSize = sizeof( CellularUrcTokenWoPrefixTable ) / sizeof( char * );

--- a/source/cellular_bg96.c
+++ b/source/cellular_bg96.c
@@ -181,13 +181,13 @@ CellularError_t Cellular_ModuleInit( const CellularContext_t * pContext,
         }
 
         #if ( CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET == 1 )
+        {
+            /* Register the URC data callback. */
+            if( cellularStatus == CELLULAR_SUCCESS )
             {
-                /* Register the URC data callback. */
-                if( cellularStatus == CELLULAR_SUCCESS )
-                {
-                    cellularStatus = _Cellular_RegisterInputBufferCallback( pContext, Cellular_BG96InputBufferCallback, pContext );
-                }
+                cellularStatus = _Cellular_RegisterInputBufferCallback( pContext, Cellular_BG96InputBufferCallback, pContext );
             }
+        }
         #endif /* CELLULAR_BG96_SUPPPORT_DIRECT_PUSH_SOCKET. */
     }
 

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -273,7 +273,6 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     int32_t tempValue = 0;
     bool parseStatus = true;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
-    bool isGsm = false;
     qcsqSerivceMode_t eQcsqSysmode;
 
     if( ( pSignalInfo == NULL ) || ( pQcsqPayload == NULL ) )

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -103,11 +103,6 @@
 
 #define MAX_QIRD_STRING_PREFIX_STRING            ( 14U )    /* The max data prefix string is "+QIRD: 1460\r\n" */
 
-#define QCSQ_SYSMODE_NOSERIVCE                  "NOSERVICE"
-#define QCSQ_SYSMODE_GSM                        "GSM"
-#define QCSQ_SYSMODE_CAT_M1                     "CAT-M1"
-#define QCSQ_SYSMODE_CAT_NB1                    "CAT-NB1"
-
 /*-----------------------------------------------------------*/
 
 /**
@@ -133,6 +128,7 @@ typedef enum qcsqSerivceMode {
 
 /*-----------------------------------------------------------*/
 
+static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod );
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo );
 static CellularPktStatus_t _Cellular_RecvFuncGetSignalInfo( CellularContext_t * pContext,
@@ -237,25 +233,25 @@ static CellularPktStatus_t socketSendDataPrefix( void * pCallbackContext,
 
 /*-----------------------------------------------------------*/
 
-static qcsqSerivceMode_t _parseQcsqServiceMode( char * pToken )
+static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod )
 {
     qcsqSerivceMode_t eQcsqSysmode;
 
-    if( strcmp( pToken, "NOSERVICE" ) == 0 )
+    if( strcmp( pSysmod, "NOSERVICE" ) == 0 )
     {
-        eQcsqSysmode = QCSQ_SYSMODE_INVALID;
+        eQcsqSysmode = QCSQ_SYSMODE_NOSERVICE;
     }
-    else if( strcmp( pToken, "GSM" ) == 0 )
+    else if( strcmp( pSysmod, "GSM" ) == 0 )
     {
-        eQcsqSysmode = QCSQ_SYSMODE_INVALID;
+        eQcsqSysmode = QCSQ_SYSMODE_GSM;
     }
-    else if( strcmp( pToken, "CAT-M1" ) == 0 )
+    else if( strcmp( pSysmod, "CAT-M1" ) == 0 )
     {
-        eQcsqSysmode = QCSQ_SYSMODE_INVALID;
+        eQcsqSysmode = QCSQ_SYSMODE_CAT_M1;
     }
-    else if( strcmp( pToken, "CAT-NB1" ) == 0 )
+    else if( strcmp( pSysmod, "CAT-NB1" ) == 0 )
     {
-        eQcsqSysmode = QCSQ_SYSMODE_INVALID;
+        eQcsqSysmode = QCSQ_SYSMODE_CAT_NB1;
     }
     else
     {
@@ -263,6 +259,8 @@ static qcsqSerivceMode_t _parseQcsqServiceMode( char * pToken )
     }
     return eQcsqSysmode;
 }
+
+/*-----------------------------------------------------------*/
 
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo )
@@ -286,7 +284,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
 
         if( eQcsqSysmode == QCSQ_SYSMODE_INVALID )
         {
-            LogError( ( "_parseSignalQuality: Invalide service mode in QCSQ Response." ) );
+            LogError( ( "_parseSignalQuality: Invalide service mode in QCSQ Response %s.", pToken ) );
             parseStatus = false;
         }
     }
@@ -305,7 +303,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         else
         {
             /* Parse value1( gsm_rssi or lte_rssi ) for GSM, CAT-M1 and CAT-NB1. */
-            if( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+            if( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS )
             {
                 atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -228,6 +228,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     int32_t tempValue = 0;
     bool parseStatus = true;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+    bool isGsm = false;
 
     if( ( pSignalInfo == NULL ) || ( pQcsqPayload == NULL ) )
     {
@@ -237,7 +238,8 @@ static bool _parseSignalQuality( char * pQcsqPayload,
 
     if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
-        if( ( strcmp( pToken, "GSM" ) != 0 ) &&
+        isGsm = strcmp( pToken, "GSM" ) == 0;
+        if( ( !isGsm ) &&
             ( strcmp( pToken, "CAT-M1" ) != 0 ) &&
             ( strcmp( pToken, "CAT-NB1" ) != 0 ) )
         {
@@ -269,7 +271,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->rsrp = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 
@@ -288,7 +294,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->sinr = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 
@@ -309,7 +319,11 @@ static bool _parseSignalQuality( char * pQcsqPayload,
         parseStatus = false;
     }
 
-    if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
+    if (isGsm)
+    {
+        pSignalInfo->rsrq = CELLULAR_INVALID_SIGNAL_VALUE;
+    }
+    else if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
         atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
 

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -118,18 +118,18 @@ typedef struct _socketDataRecv
 /**
  * @brief AT+QCSQ supported service mode.
  */
-typedef enum qcsqSerivceMode
+typedef enum qcsqServiceMode
 {
     QCSQ_SYSMODE_NOSERVICE,
     QCSQ_SYSMODE_GSM,
     QCSQ_SYSMODE_CAT_M1,
     QCSQ_SYSMODE_CAT_NB1,
     QCSQ_SYSMODE_INVALID
-} qcsqSerivceMode_t;
+} qcsqServiceMode_t;
 
 /*-----------------------------------------------------------*/
 
-static qcsqSerivceMode_t _parseQcsqSysmode( char * pSysmode );
+static qcsqServiceMode_t _parseQcsqSysmode( char * pSysmode );
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo );
 static CellularPktStatus_t _Cellular_RecvFuncGetSignalInfo( CellularContext_t * pContext,
@@ -234,9 +234,9 @@ static CellularPktStatus_t socketSendDataPrefix( void * pCallbackContext,
 
 /*-----------------------------------------------------------*/
 
-static qcsqSerivceMode_t _parseQcsqSysmode( char * pSysmode )
+static qcsqServiceMode_t _parseQcsqSysmode( char * pSysmode )
 {
-    qcsqSerivceMode_t eQcsqSysmode;
+    qcsqServiceMode_t eQcsqSysmode;
 
     if( strcmp( pSysmode, "NOSERVICE" ) == 0 )
     {
@@ -265,7 +265,13 @@ static qcsqSerivceMode_t _parseQcsqSysmode( char * pSysmode )
 /*-----------------------------------------------------------*/
 
 /* Parsing the AT+QCSQ response. The response is of the following format:
- * +QCSQ: <sysmode>,[,<value1>[,<value2>[,<value3>[,<value4>]]]]. */
+ * +QCSQ: <sysmode>,[,<value1>[,<value2>[,<value3>[,<value4>]]]].
+ * <sysmode>    <value1>    <value2>    <value3>    <value4>    
+ * "NOSERVICE"  N/A         N/A         N/A         N/A
+ * "GSM"        <gsm_rssi>  N/A         N/A         N/A
+ * "CAT-M1"     <lte_resi>  <lte_rsrp>  <lte_sinr>  <lte_rsrq>
+ * "CAT-NB1"    <lte_resi>  <lte_rsrp>  <lte_sinr>  <lte_rsrq>
+ */
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo )
 {
@@ -273,7 +279,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
     int32_t tempValue = 0;
     bool parseStatus = true;
     CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
-    qcsqSerivceMode_t eQcsqSysmode;
+    qcsqServiceMode_t eQcsqSysmode;
 
     if( ( pSignalInfo == NULL ) || ( pQcsqPayload == NULL ) )
     {

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -118,7 +118,8 @@ typedef struct _socketDataRecv
 /**
  * @brief AT+QCSQ supported service mode.
  */
-typedef enum qcsqSerivceMode {
+typedef enum qcsqSerivceMode
+{
     QCSQ_SYSMODE_NOSERVICE,
     QCSQ_SYSMODE_GSM,
     QCSQ_SYSMODE_CAT_M1,
@@ -257,6 +258,7 @@ static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod )
     {
         eQcsqSysmode = QCSQ_SYSMODE_INVALID;
     }
+
     return eQcsqSysmode;
 }
 

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -129,7 +129,7 @@ typedef enum qcsqServiceMode
 
 /*-----------------------------------------------------------*/
 
-static qcsqServiceMode_t _parseQcsqSysmode( char * pSysmode );
+static qcsqServiceMode_t _parseQcsqServiceMode( char * pSysmode );
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo );
 static CellularPktStatus_t _Cellular_RecvFuncGetSignalInfo( CellularContext_t * pContext,
@@ -234,7 +234,7 @@ static CellularPktStatus_t socketSendDataPrefix( void * pCallbackContext,
 
 /*-----------------------------------------------------------*/
 
-static qcsqServiceMode_t _parseQcsqSysmode( char * pSysmode )
+static qcsqServiceMode_t _parseQcsqServiceMode( char * pSysmode )
 {
     qcsqServiceMode_t eQcsqSysmode;
 
@@ -266,7 +266,7 @@ static qcsqServiceMode_t _parseQcsqSysmode( char * pSysmode )
 
 /* Parsing the AT+QCSQ response. The response is of the following format:
  * +QCSQ: <sysmode>,[,<value1>[,<value2>[,<value3>[,<value4>]]]].
- * <sysmode>    <value1>    <value2>    <value3>    <value4>    
+ * <sysmode>    <value1>    <value2>    <value3>    <value4>
  * "NOSERVICE"  N/A         N/A         N/A         N/A
  * "GSM"        <gsm_rssi>  N/A         N/A         N/A
  * "CAT-M1"     <lte_resi>  <lte_rsrp>  <lte_sinr>  <lte_rsrq>
@@ -289,7 +289,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
 
     if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
-        eQcsqSysmode = _parseQcsqSysmode( pToken );
+        eQcsqSysmode = _parseQcsqServiceMode( pToken );
 
         if( eQcsqSysmode == QCSQ_SYSMODE_INVALID )
         {

--- a/source/cellular_bg96_api.c
+++ b/source/cellular_bg96_api.c
@@ -129,7 +129,7 @@ typedef enum qcsqSerivceMode
 
 /*-----------------------------------------------------------*/
 
-static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod );
+static qcsqSerivceMode_t _parseQcsqSysmode( char * pSysmode );
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo );
 static CellularPktStatus_t _Cellular_RecvFuncGetSignalInfo( CellularContext_t * pContext,
@@ -234,23 +234,23 @@ static CellularPktStatus_t socketSendDataPrefix( void * pCallbackContext,
 
 /*-----------------------------------------------------------*/
 
-static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod )
+static qcsqSerivceMode_t _parseQcsqSysmode( char * pSysmode )
 {
     qcsqSerivceMode_t eQcsqSysmode;
 
-    if( strcmp( pSysmod, "NOSERVICE" ) == 0 )
+    if( strcmp( pSysmode, "NOSERVICE" ) == 0 )
     {
         eQcsqSysmode = QCSQ_SYSMODE_NOSERVICE;
     }
-    else if( strcmp( pSysmod, "GSM" ) == 0 )
+    else if( strcmp( pSysmode, "GSM" ) == 0 )
     {
         eQcsqSysmode = QCSQ_SYSMODE_GSM;
     }
-    else if( strcmp( pSysmod, "CAT-M1" ) == 0 )
+    else if( strcmp( pSysmode, "CAT-M1" ) == 0 )
     {
         eQcsqSysmode = QCSQ_SYSMODE_CAT_M1;
     }
-    else if( strcmp( pSysmod, "CAT-NB1" ) == 0 )
+    else if( strcmp( pSysmode, "CAT-NB1" ) == 0 )
     {
         eQcsqSysmode = QCSQ_SYSMODE_CAT_NB1;
     }
@@ -264,6 +264,8 @@ static qcsqSerivceMode_t _parseQcsqServiceMode( char * pSysmod )
 
 /*-----------------------------------------------------------*/
 
+/* Parsing the AT+QCSQ response. The response is of the following format:
+ * +QCSQ: <sysmode>,[,<value1>[,<value2>[,<value3>[,<value4>]]]]. */
 static bool _parseSignalQuality( char * pQcsqPayload,
                                  CellularSignalInfo_t * pSignalInfo )
 {
@@ -282,7 +284,7 @@ static bool _parseSignalQuality( char * pQcsqPayload,
 
     if( ( parseStatus == true ) && ( Cellular_ATGetNextTok( &pTmpQcsqPayload, &pToken ) == CELLULAR_AT_SUCCESS ) )
     {
-        eQcsqSysmode = _parseQcsqServiceMode( pToken );
+        eQcsqSysmode = _parseQcsqSysmode( pToken );
 
         if( eQcsqSysmode == QCSQ_SYSMODE_INVALID )
         {

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -80,16 +80,16 @@ static CellularPktStatus_t prvStoreDirectPushSocketData( CellularContext_t * pCo
 /* coverity[misra_c_2012_rule_8_7_violation] */
 CellularAtParseTokenMap_t CellularUrcHandlerTable[] =
 {
-    { "CEREG",             Cellular_CommonUrcProcessCereg },
-    { "CGREG",             Cellular_CommonUrcProcessCgreg },
-    { "CREG",              Cellular_CommonUrcProcessCreg  },
-    { "POWERED DOWN", _Cellular_ProcessPowerDown     },
-    { "PSM POWER DOWN",    _Cellular_ProcessPsmPowerDown  },
-    { "QIND",              _Cellular_ProcessIndication    },
-    { "QIOPEN",            _Cellular_ProcessSocketOpen    },
-    { "QIURC",             _Cellular_ProcessSocketurc     },
-    { "QSIMSTAT",          _Cellular_ProcessSimstat       },
-    { "RDY",               _Cellular_ProcessModemRdy      }
+    { "CEREG",          Cellular_CommonUrcProcessCereg },
+    { "CGREG",          Cellular_CommonUrcProcessCgreg },
+    { "CREG",           Cellular_CommonUrcProcessCreg  },
+    { "POWERED DOWN",   _Cellular_ProcessPowerDown     },
+    { "PSM POWER DOWN", _Cellular_ProcessPsmPowerDown  },
+    { "QIND",           _Cellular_ProcessIndication    },
+    { "QIOPEN",         _Cellular_ProcessSocketOpen    },
+    { "QIURC",          _Cellular_ProcessSocketurc     },
+    { "QSIMSTAT",       _Cellular_ProcessSimstat       },
+    { "RDY",            _Cellular_ProcessModemRdy      }
 };
 
 /* FreeRTOS Cellular Common Library porting interface. */

--- a/source/cellular_bg96_urc_handler.c
+++ b/source/cellular_bg96_urc_handler.c
@@ -65,7 +65,7 @@ CellularAtParseTokenMap_t CellularUrcHandlerTable[] =
     { "CEREG",             Cellular_CommonUrcProcessCereg },
     { "CGREG",             Cellular_CommonUrcProcessCgreg },
     { "CREG",              Cellular_CommonUrcProcessCreg  },
-    { "NORMAL POWER DOWN", _Cellular_ProcessPowerDown     },
+    { "POWERED DOWN", _Cellular_ProcessPowerDown     },
     { "PSM POWER DOWN",    _Cellular_ProcessPsmPowerDown  },
     { "QIND",              _Cellular_ProcessIndication    },
     { "QIOPEN",            _Cellular_ProcessSocketOpen    },


### PR DESCRIPTION
Continue #9 in this PR to fix AT+QCSQ for GSM and NOSERVICE mode

Description
-----------
In this PR,
* Ignores LTE only signal quality values in the case the modem is connected via GSM
* Add NOSERVICE sysmode support
* Update power down URC

Test Steps
-----------


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.

Related Issue
-----------
#8 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
